### PR TITLE
Step4 kd tree division

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**7 # Recommend 2**11 for accurate computation. 
+Nside = 2**2 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**6 # Recommend 2**11 for accurate computation. 
+Nside = 2**7 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**4 # Recommend 2**11 for accurate computation. 
+Nside = 2**6 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  
@@ -41,12 +41,13 @@ NESTED = True # Use nested HEALPix division by default for histogramming.
 # user must specify a list of tuples (one per quantity) as in the following example.
 import numpy as np
 
-templates = [("Nexp","none", "sum"),
-             ("airmass","galdepth_ivar", "min"),
-             ("airmass","none", "mean"),             
-             ("airmass","galdepth_ivar", "mean"),
-             ("ebv","galdepth_ivar", "mean"),
-             ("seeing","galdepth_ivar", "mean"),
+templates = [
+			# ("Nexp","none", "sum"),
+             # ("airmass","galdepth_ivar", "min"),
+             # ("airmass","none", "mean"),             
+             # ("airmass","galdepth_ivar", "mean"),
+             # ("ebv","galdepth_ivar", "mean"),
+             # ("seeing","galdepth_ivar", "mean"),
              ("avsky","galdepth_ivar", "mean")]
 
 # More generally,

--- a/config_serial_membound.py
+++ b/config_serial_membound.py
@@ -17,7 +17,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**7 # Recommend 2**11 for accurate computation. 
+Nside = 2**11 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  
@@ -39,7 +39,7 @@ NESTED = True # Use nested HEALPix division by default for histogramming.
 
 # Number of pixels in each unit before matching to ccd_centers. (Slows down
 # the computation by ~2 but reduces memory requirement.)
-Nside_kdtree = 2**7
+Nside_kdtree = 2**9
 # WARNING: Must be in powers of 2.
 # A guide on the choice of Nside_kdtree:
 # The expected number of matches between the ccd centers and pixel centers 
@@ -50,20 +50,20 @@ Nside_kdtree = 2**7
 # average. (For DR3, num_ccd_avg ~6.) Putting the two figures together 
 # this means we expect about (num_pix * num_ccd_avg/3.) matches between ccds
 # and the pixels. As an example, for DR3 with Nside = 2^11 case, we would 
-# expect 54M = (50M * 6 * 0.18) matches. That's 108 MB of memory for numpy arrays
+# expect 54M = (50M * 6 * 0.18) matches. That's 432 MB of memory for numpy arrays
 # for match indices. For the compelete DESI imaging survey, we would instead
 # expect (as an upper bound) 330M = (50M * 20 * 1/3.) matches. That translates
-# to almost 0.7 GB of memory. More importantly, the kd-tree algorithm that the program implements
+# to almost 2.8 GB of memory. More importantly, the kd-tree algorithm that the program implements
 # requires RAM memory that grows proportinate to the number of input pixels.
-# For DR3, Nside = 2^11 case, the requirement is 6GB! So to be conservative
+# For DR3, Nside = 2^11 case, the requirement is over 15GB! So to be conservative
 # in memory requirement, we opt to divide the computation into several units 
 # with each unit containing hp.nside2npix(Nside_kdtree) pixels. In Nside = 2^9 case, 
-# kd-tree takes up about 1.5 GB (or less) and since the computation 
+# kd-tree takes up about 3 GB (or less) and since the computation 
 # is done on chunks, there is no worry of running out of RAM memory at least
 # for computing pixel-ccd matches. However, this does mean the computation
 # is done in 16 = (2^11/2^9) chunks, which will add to overhead. 
 # If the number of matches grows by another factor of 10, say, because more 
-# data was taken then that translates to 7 GB of memory just for indices!
+# data was taken then that translates to 28 GB of memory just for indices!
 # That would require saving the matched indices into files, out of RAM,
 # which my current implementation does not do.
 

--- a/config_serial_membound.py
+++ b/config_serial_membound.py
@@ -17,7 +17,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**6 # Recommend 2**11 for accurate computation. 
+Nside = 2**9 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  
@@ -38,7 +38,8 @@ NESTED = True # Use nested HEALPix division by default for histogramming.
 # Use Nside = 2^11. Pixel size is about 1 percent of the ccd size.
 
 # Number of pixels in each unit before matching to ccd_centers. 
-Nside_kdtree = 2**4
+Nside_kdtree = 2**7
+# WARNING: Must be in powers of 2.
 # A guide on the choice of Nside_kdtree:
 # The expected number of matches between the ccd centers and pixel centers 
 # can be estimated as follows: DESI covers about the third of the sky, so 
@@ -51,7 +52,7 @@ Nside_kdtree = 2**4
 # expect 54M = (50M * 6 * 0.18) matches. That's 108 MB of memory for numpy arrays
 # for match indices. For the compelete DESI imaging survey, we would instead
 # expect (as an upper bound) 330M = (50M * 20 * 1/3.) matches. That translates
-# to almost 1 GB of memory! Also, the kd-tree algorithm that the program implements
+# to almost 0.7 GB of memory. More importantly, the kd-tree algorithm that the program implements
 # requires RAM memory that grows proportinate to the number of input pixels.
 # For DR3, Nside = 2^11 case, the requirement is 6GB! So to be conservative
 # in memory requirement, we opt to divide the computation into several units 
@@ -59,8 +60,11 @@ Nside_kdtree = 2**4
 # kd-tree takes up about 1.5 GB (or less) and since the computation 
 # is done on chunks, there is no worry of running out of RAM memory at least
 # for computing pixel-ccd matches. However, this does mean the computation
-# is done in 16 = (2^11/2^9) chunks, which will add to overhead (due to, for 
-# example, file I/O).
+# is done in 16 = (2^11/2^9) chunks, which will add to overhead. 
+# If the number of matches grows by another factor of 10, say, because more 
+# data was taken then that translates to 7 GB of memory just for indices!
+# That would require saving the matched indices into files, out of RAM,
+# which my current implementation does not do.
 
 # Quantities of interests: For any quantity that the user is interested in, 
 # user must specify a list of tuples (one per quantity) as in the following example.

--- a/config_serial_membound.py
+++ b/config_serial_membound.py
@@ -17,7 +17,7 @@ out_directory = "./"
 sepdeg = 0.336/2. 
 
 # HEALPix parameters
-Nside = 2**9 # Recommend 2**11 for accurate computation. 
+Nside = 2**7 # Recommend 2**11 for accurate computation. 
 			# WARNING: If more than 2**11, then compute time might be excessively long.
             # If less than 2**9, the approximation scheme used may not work as well.
 NESTED = True # Use nested HEALPix division by default for histogramming.  
@@ -37,7 +37,8 @@ NESTED = True # Use nested HEALPix division by default for histogramming.
 # 14 -  3,221,225,472     0.0000128             165      0.0003        0.031
 # Use Nside = 2^11. Pixel size is about 1 percent of the ccd size.
 
-# Number of pixels in each unit before matching to ccd_centers. 
+# Number of pixels in each unit before matching to ccd_centers. (Slows down
+# the computation by ~2 but reduces memory requirement.)
 Nside_kdtree = 2**7
 # WARNING: Must be in powers of 2.
 # A guide on the choice of Nside_kdtree:
@@ -68,12 +69,13 @@ Nside_kdtree = 2**7
 
 # Quantities of interests: For any quantity that the user is interested in, 
 # user must specify a list of tuples (one per quantity) as in the following example.
-templates = [("Nexp","none", "sum"),
-             ("airmass","galdepth_ivar", "min"),
-             ("airmass","none", "mean"),             
-             ("airmass","galdepth_ivar", "mean"),
-             ("ebv","galdepth_ivar", "mean"),
-             ("seeing","galdepth_ivar", "mean"),
+templates = [
+			 # ("Nexp","none", "sum"),
+             # ("airmass","galdepth_ivar", "min"),
+             # ("airmass","none", "mean"),             
+             # ("airmass","galdepth_ivar", "mean"),
+             # ("ebv","galdepth_ivar", "mean"),
+             # ("seeing",	"galdepth_ivar", "mean"),
              ("avsky","galdepth_ivar", "mean")]
 
 # More generally,

--- a/runscript_serial_membound.py
+++ b/runscript_serial_membound.py
@@ -183,12 +183,8 @@ for i in range(nchunks):
     chunk_start = i*num_pix_kdtree # Start index 
     chunk_end = (i+1)*num_pix_kdtree # End index
 
-    if i == 0:
-        # We make c_pix the first argument because we want the mapping to be sorted by it.
-        idx_pix_temp, idx_ccd_temp, _, _ = search_around_sky(c_pix[chunk_start:chunk_end], c_ccd, seplimit=sepdeg*u.degree, storekdtree='kdtree_sky')
-    else:
-        # We make c_pix the first argument because we want the mapping to be sorted by it.
-        idx_pix_temp, idx_ccd_temp, _, _ = search_around_sky(c_pix[chunk_start:chunk_end], c_ccd, seplimit=sepdeg*u.degree)
+    # We make c_pix the first argument because we want the mapping to be sorted by it.
+    idx_pix_temp, idx_ccd_temp, _, _ = search_around_sky(c_pix[chunk_start:chunk_end], c_ccd, seplimit=sepdeg*u.degree, storekdtree='kdtree_sky')
 
     # Append the temp variables to the lists.
     idx_pix_list.append(idx_pix_temp)
@@ -212,160 +208,160 @@ print("\n")
 
 
 
-# ################################################################################	
-# # - 5. Trim the list of matches: For each HEALPix pixel (referred to as pixel 
-# #	from here on), find a set of ccds that it actually belongs to. This can 
-# #	be done efficiently in cartesian represntation of ra/dec's as described 
-# #	in the code below. The cartesian represntation is pre-computed. 
-# print("5. Trim the list of matches")
-# print("5a: Loading ra/dec bounding corners and covert them (and pixel ra/dec) to xyz on unit sphere.")
-# start = time.time()
+################################################################################	
+# - 5. Trim the list of matches: For each HEALPix pixel (referred to as pixel 
+#	from here on), find a set of ccds that it actually belongs to. This can 
+#	be done efficiently in cartesian represntation of ra/dec's as described 
+#	in the code below. The cartesian represntation is pre-computed. 
+print("5. Trim the list of matches")
+print("5a: Loading ra/dec bounding corners and covert them (and pixel ra/dec) to xyz on unit sphere.")
+start = time.time()
 
-# # Load ra/dec of ccd bounding corners.
-# ra0, ra1, ra2, ra3, dec0, dec1, dec2, dec3 = load_radec_corners(data_ccd)
+# Load ra/dec of ccd bounding corners.
+ra0, ra1, ra2, ra3, dec0, dec1, dec2, dec3 = load_radec_corners(data_ccd)
 
-# # Convert ra/dec to xyz vectors
-# xyz0_ccd = radec2xyz(ra0,dec0)
-# xyz1_ccd = radec2xyz(ra1,dec1)
-# xyz2_ccd = radec2xyz(ra2,dec2)
-# xyz3_ccd = radec2xyz(ra3,dec3)
+# Convert ra/dec to xyz vectors
+xyz0_ccd = radec2xyz(ra0,dec0)
+xyz1_ccd = radec2xyz(ra1,dec1)
+xyz2_ccd = radec2xyz(ra2,dec2)
+xyz3_ccd = radec2xyz(ra3,dec3)
 
-# # Compute the normal vectors. The idea here is that given four normal vectors that 
-# # are the results of cross-producting (xyz1,xyz0), (0,3), (3,2), (2,1) in that order, 
-# # we can simply dot prodcut with normal vectors represented by healpix center.
-# # The subtraction is done for numerically stability. Members of n0_ccd-n_pix 
-# # are quite similar.
-# n0_ccd  = np.cross(xyz1_ccd-xyz0_ccd, xyz0_ccd)
-# n1_ccd  = np.cross(xyz0_ccd-xyz3_ccd, xyz3_ccd)
-# n2_ccd  = np.cross(xyz3_ccd-xyz2_ccd, xyz2_ccd)
-# n3_ccd  = np.cross(xyz2_ccd-xyz1_ccd, xyz1_ccd)
+# Compute the normal vectors. The idea here is that given four normal vectors that 
+# are the results of cross-producting (xyz1,xyz0), (0,3), (3,2), (2,1) in that order, 
+# we can simply dot prodcut with normal vectors represented by healpix center.
+# The subtraction is done for numerically stability. Members of n0_ccd-n_pix 
+# are quite similar.
+n0_ccd  = np.cross(xyz1_ccd-xyz0_ccd, xyz0_ccd)
+n1_ccd  = np.cross(xyz0_ccd-xyz3_ccd, xyz3_ccd)
+n2_ccd  = np.cross(xyz3_ccd-xyz2_ccd, xyz2_ccd)
+n3_ccd  = np.cross(xyz2_ccd-xyz1_ccd, xyz1_ccd)
 
-# # Create x,y,z vector version of healpix centers.
-# xyz_pix = np.asarray(c_pix.cartesian.xyz).T
-# dt5a = time.time()-start
-# print("Finished. Time elapsed: %.3E sec\n"% (dt5a))
+# Create x,y,z vector version of healpix centers.
+xyz_pix = np.asarray(c_pix.cartesian.xyz).T
+dt5a = time.time()-start
+print("Finished. Time elapsed: %.3E sec\n"% (dt5a))
 
-# # Vectorized version. 
-# print("5b. Trimming ccd to pix mapping to only pairs where pix center resides inside the matching ccd.")
-# start = time.time()
+# Vectorized version. 
+print("5b. Trimming ccd to pix mapping to only pairs where pix center resides inside the matching ccd.")
+start = time.time()
 
-# # Get xyz vector of healpix center
-# n_pix = xyz_pix[idx_pix]
+# Get xyz vector of healpix center
+n_pix = xyz_pix[idx_pix]
 
-# # Test whether the pixel center is within each of the matched CCD
-# ibool = np.logical_and.reduce((vectorized_dot(n0_ccd[idx_ccd],n_pix)>0, 
-#                                vectorized_dot(n1_ccd[idx_ccd],n_pix)>0, 
-#                                vectorized_dot(n2_ccd[idx_ccd],n_pix)>0, 
-#                                vectorized_dot(n3_ccd[idx_ccd],n_pix)>0))
+# Test whether the pixel center is within each of the matched CCD
+ibool = np.logical_and.reduce((vectorized_dot(n0_ccd[idx_ccd],n_pix)>0, 
+                               vectorized_dot(n1_ccd[idx_ccd],n_pix)>0, 
+                               vectorized_dot(n2_ccd[idx_ccd],n_pix)>0, 
+                               vectorized_dot(n3_ccd[idx_ccd],n_pix)>0))
 
-# # Trimming the mapping.
-# idx_pix_inside = idx_pix[ibool]
-# idx_ccd_inside = idx_ccd[ibool]
-# dt5b = time.time()-start
-# print("Finished. Time elapsed: %.3E sec\n"% (dt5b))
+# Trimming the mapping.
+idx_pix_inside = idx_pix[ibool]
+idx_ccd_inside = idx_ccd[ibool]
+dt5b = time.time()-start
+print("Finished. Time elapsed: %.3E sec\n"% (dt5b))
 
-# print("From here on work with pixels that were found to be in at least one ccd.")
-# idx_pix_inside_uniq = np.unique(idx_pix_inside)
-# num_pix_inside_uniq = idx_pix_inside_uniq.size
-# print("Pix # Beginning, # Spherematched, # Inside: %d, %d, %d "%(num_pix,num_pix_uniq,num_pix_inside_uniq))
-# print("\n")
-
-
-
-# ################################################################################
-# # - 6. Compute the stats: See above.
-# print("6. Compute the stats")
-# print("Allocate memory for the output array.")
-# # Create the output recarray as a placeholder.
-# rec_dtype = gen_rec_dtype(templates)
-# num_col = 3*len(templates)+3
-# output_arr = np.recarray((num_pix_inside_uniq,),dtype=rec_dtype)
-
-# # Overwrite for the HEALPix portion.
-# output_arr["hpix_idx"] = idx_pix_inside_uniq
-# output_arr["hpix_ra"],output_arr["hpix_dec"] = hp.pix2ang(Nside,idx_pix_inside_uniq,nest=True,lonlat=True)
-
-# # Filter types
-# filter_types = ["g","r","z"]
-
-# # Before proceeding, if any of the templates specified "weight" = "galdepth_ivar", then compute the quanity.
-# for e in templates:
-#     if e[1]=="galdepth_ivar":
-#         print("Compute galdepth_ivar.")
-#         galdepth_ivar = fluxlim2ivar(mag2flux(data_ccd["galdepth"]))
-#         break
-
-# # Import ccd_filter
-# ccd_filter = data_ccd["filter"]
-
-# # Look-up dictionary for efficient assigning of numbers after computation.
-# eb_dict = template_filter_dict(templates, filter_types)
+print("From here on work with pixels that were found to be in at least one ccd.")
+idx_pix_inside_uniq = np.unique(idx_pix_inside)
+num_pix_inside_uniq = idx_pix_inside_uniq.size
+print("Pix # Beginning, # Spherematched, # Inside: %d, %d, %d "%(num_pix,num_pix_uniq,num_pix_inside_uniq))
+print("\n")
 
 
-# # Version: Using scipy binned_statistic
-# print("Start computing statistics.")
-# start = time.time()
 
-# # For each filter
-# for b in filter_types:
-#     print("Computation for %s-band quantities started."%b)	
-#     # Create a band mask
-#     i_b = data_ccd["filter"][idx_ccd_inside]==b
+################################################################################
+# - 6. Compute the stats: See above.
+print("6. Compute the stats")
+print("Allocate memory for the output array.")
+# Create the output recarray as a placeholder.
+rec_dtype = gen_rec_dtype(templates)
+num_col = 3*len(templates)+3
+output_arr = np.recarray((num_pix_inside_uniq,),dtype=rec_dtype)
 
-#     # Sum of galdepth_ivar per bin
-#     # For galdepth_ivar average:
-#     hist_denom_galdepth_ivar, _, _ = stats.binned_statistic(idx_pix_inside[i_b], galdepth_ivar[idx_ccd_inside[i_b]], statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))
+# Overwrite for the HEALPix portion.
+output_arr["hpix_idx"] = idx_pix_inside_uniq
+output_arr["hpix_ra"],output_arr["hpix_dec"] = hp.pix2ang(Nside,idx_pix_inside_uniq,nest=True,lonlat=True)
 
-#     # For each quantity requsted
-#     for e in templates:
-#         start_e = time.time()
-#         if (e[1] == "none") or (e[2] in ["min", "max", "median"]): 
-#             # If the weight scheme is none or any of the above functions were chosen.
-#             weight = False
-#         else:
-#             weight = True
+# Filter types
+filter_types = ["g","r","z"]
+
+# Before proceeding, if any of the templates specified "weight" = "galdepth_ivar", then compute the quanity.
+for e in templates:
+    if e[1]=="galdepth_ivar":
+        print("Compute galdepth_ivar.")
+        galdepth_ivar = fluxlim2ivar(mag2flux(data_ccd["galdepth"]))
+        break
+
+# Import ccd_filter
+ccd_filter = data_ccd["filter"]
+
+# Look-up dictionary for efficient assigning of numbers after computation.
+eb_dict = template_filter_dict(templates, filter_types)
+
+
+# Version: Using scipy binned_statistic
+print("Start computing statistics.")
+start = time.time()
+
+# For each filter
+for b in filter_types:
+    print("Computation for %s-band quantities started."%b)	
+    # Create a band mask
+    i_b = data_ccd["filter"][idx_ccd_inside]==b
+
+    # Sum of galdepth_ivar per bin
+    # For galdepth_ivar average:
+    hist_denom_galdepth_ivar, _, _ = stats.binned_statistic(idx_pix_inside[i_b], galdepth_ivar[idx_ccd_inside[i_b]], statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))
+
+    # For each quantity requsted
+    for e in templates:
+        start_e = time.time()
+        if (e[1] == "none") or (e[2] in ["min", "max", "median"]): 
+            # If the weight scheme is none or any of the above functions were chosen.
+            weight = False
+        else:
+            weight = True
         
-#         # If the quantity requested is Nexp
-#         if (e[0] == "Nexp"): # Nexp is not part of ccd file summary so treated like a special case
-#             hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], np.ones_like([idx_ccd_inside[i_b]]), statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))            
-#             output_arr[eb_dict[(e,b)]] = hist_num[0][idx_pix_inside_uniq]            
-#         else:
-#             # If the operation asked for is mean
-#             if e[2] == "mean": 
-#                 if weight: # weight is true, apply the weights when computing the average.
-#                     hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]]*galdepth_ivar[idx_ccd_inside[i_b]], statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))
-#                     output_arr[eb_dict[(e,b)]] = (hist_num[idx_pix_inside_uniq]/hist_denom_galdepth_ivar[idx_pix_inside_uniq])  
-#                 else: # weight is FALSE, then just use "mean" option. 
-#                     hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]], statistic = "mean", bins=np.arange(-0.5, num_pix+1.5, 1))
-#                     output_arr[eb_dict[(e,b)]] = hist_num[idx_pix_inside_uniq]
-#             # For all other operations.
-#             else:
-#                 hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]], statistic = e[2], bins=np.arange(-0.5, num_pix+1.5, 1))
-#                 output_arr[eb_dict[(e,b)]] = hist_num[idx_pix_inside_uniq]
-#         print(("Quantity: %s, Time taken: {:<1.3E} sec"%eb_dict[(e,b)]).format(time.time()-start_e))
-#     print("Computation for %s-band quantities ended.\n"%b)    
+        # If the quantity requested is Nexp
+        if (e[0] == "Nexp"): # Nexp is not part of ccd file summary so treated like a special case
+            hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], np.ones_like([idx_ccd_inside[i_b]]), statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))            
+            output_arr[eb_dict[(e,b)]] = hist_num[0][idx_pix_inside_uniq]            
+        else:
+            # If the operation asked for is mean
+            if e[2] == "mean": 
+                if weight: # weight is true, apply the weights when computing the average.
+                    hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]]*galdepth_ivar[idx_ccd_inside[i_b]], statistic = "sum", bins=np.arange(-0.5, num_pix+1.5, 1))
+                    output_arr[eb_dict[(e,b)]] = (hist_num[idx_pix_inside_uniq]/hist_denom_galdepth_ivar[idx_pix_inside_uniq])  
+                else: # weight is FALSE, then just use "mean" option. 
+                    hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]], statistic = "mean", bins=np.arange(-0.5, num_pix+1.5, 1))
+                    output_arr[eb_dict[(e,b)]] = hist_num[idx_pix_inside_uniq]
+            # For all other operations.
+            else:
+                hist_num, _, _= stats.binned_statistic(idx_pix_inside[i_b], data_ccd[e[0]][idx_ccd_inside[i_b]], statistic = e[2], bins=np.arange(-0.5, num_pix+1.5, 1))
+                output_arr[eb_dict[(e,b)]] = hist_num[idx_pix_inside_uniq]
+        print(("Quantity: %s, Time taken: {:<1.3E} sec"%eb_dict[(e,b)]).format(time.time()-start_e))
+    print("Computation for %s-band quantities ended.\n"%b)    
                 
-# dt6 = time.time()-start
-# print("Finished. Time elapsed: %.3E sec"% (dt6))
-# # At the moment, saved in numpy binary file.
-# np.save("".join([out_directory, "output_arr"]), output_arr, allow_pickle=False)
-# print("output_arr is saved in %s." % out_directory)
-# print("\n")
+dt6 = time.time()-start
+print("Finished. Time elapsed: %.3E sec"% (dt6))
+# At the moment, saved in numpy binary file.
+np.save("".join([out_directory, "output_arr"]), output_arr, allow_pickle=False)
+print("output_arr is saved in %s." % out_directory)
+print("\n")
 
 
 
-# ################################################################################
-# # - 7. Report times of various steps.
-# print("{:<40s}: {:<1.3E} sec".format("Check config file", dt1))
-# print("{:<40s}: {:<1.3E} sec".format("Load CCD data", dt2))
-# print("{:<40s}: {:<1.3E} sec".format("Create HEALPix grid", dt3))
-# print("{:<40s}: {:<1.3E} sec".format("Spherematch pixels to ccd centers", dt4))
-# print("{:<40s}: {:<1.3E} sec".format("Pre-compute xyz coordinates", dt5a))
-# print("{:<40s}: {:<1.3E} sec".format("Trim the spherematch list", dt5b))
-# print("{:<40s}: {:<1.3E} sec".format("Compute the statistics", dt6))
-# print("# ccds USED after masking: {:>,d} ({:2.2f} pcnt)".format(num_ccd_used,(num_ccd_used)/num_ccds_total * 100))
-# print("Pix # Beginning, # Spherematched, # Inside: %d, %d, %d "%(num_pix,num_pix_uniq,num_pix_inside_uniq))
-# print("Number of matches (length of idx_pix): {:>,d}".format(idx_pix.size))
+################################################################################
+# - 7. Report times of various steps.
+print("{:<40s}: {:<1.3E} sec".format("Check config file", dt1))
+print("{:<40s}: {:<1.3E} sec".format("Load CCD data", dt2))
+print("{:<40s}: {:<1.3E} sec".format("Create HEALPix grid", dt3))
+print("{:<40s}: {:<1.3E} sec".format("Spherematch pixels to ccd centers", dt4))
+print("{:<40s}: {:<1.3E} sec".format("Pre-compute xyz coordinates", dt5a))
+print("{:<40s}: {:<1.3E} sec".format("Trim the spherematch list", dt5b))
+print("{:<40s}: {:<1.3E} sec".format("Compute the statistics", dt6))
+print("# ccds USED after masking: {:>,d} ({:2.2f} pcnt)".format(num_ccd_used,(num_ccd_used)/num_ccds_total * 100))
+print("Pix # Beginning, # Spherematched, # Inside: %d, %d, %d "%(num_pix,num_pix_uniq,num_pix_inside_uniq))
+print("Number of matches (length of idx_pix): {:>,d}".format(idx_pix.size))
 
 
 

--- a/runscript_serial_membound.py
+++ b/runscript_serial_membound.py
@@ -186,9 +186,10 @@ for i in range(nchunks):
     # We make c_pix the first argument because we want the mapping to be sorted by it.
     idx_pix_temp, idx_ccd_temp, _, _ = search_around_sky(c_pix[chunk_start:chunk_end], c_ccd, seplimit=sepdeg*u.degree, storekdtree='kdtree_sky')
 
-    # Append the temp variables to the lists.
-    idx_pix_list.append(idx_pix_temp)
-    idx_ccd_list.append(idx_ccd_temp)
+    # Append the temp variables to the lists, if the size is nonzero.
+    if idx_pix_temp.size > 0: 
+        idx_pix_list.append(idx_pix_temp+chunk_start)
+        idx_ccd_list.append(idx_ccd_temp)
 
     # This may not work if there are chunks with no matches at all.
     print("Computing chunk %d. Time took %.3E sec"%(i, time.time()-start_time_chunk))


### PR DESCRIPTION
The runscript_serial_membound.py implements a version of the program that divides the computation in chunks with each chunk having hp.nside2npix(Nside_kdtree) number of pixels. This version has two shortcomings that could be improved. 1) Step 4. spherematching algorithm: Instead of using astropy, we could try using Daniel Eisenstein's spherematch C-code that could be faster. Have to figure out how to port it to Python. 2) Step 6. scipy.stats.binned_statistic: Min/Max/Median calculations are about 500x slower. It might be possible to improve this algorithm.

Rather than doing all the chunks serially in one run, run the program one chunk at a time and combine the outputs downstream. This is what I will do next.